### PR TITLE
docs: add getoutline to wiki section

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ Here are some useful tools for note-taking and creating wikis:
 - [Notion](https://www.notion.so/)
 - [Obsidian](https://obsidian.md/)
 - [Confluence](https://www.atlassian.com/software/confluence)
+- [Outline](https://www.getoutline.com/)
 
 Read more:
 


### PR DESCRIPTION
Add the software https://www.getoutline.com/ to the wiki section. I would say it's worth the mention.